### PR TITLE
Remove default File module import

### DIFF
--- a/elm_rs/src/lib.rs
+++ b/elm_rs/src/lib.rs
@@ -50,7 +50,6 @@ macro_rules! export {
 module {} exposing (..)
 
 import Dict exposing (Dict)
-import File
 import Http
 import Json.Decode
 import Json.Encode


### PR DESCRIPTION
The codegen is adding an unnecessary extra import, as far as I can tell. I don't see `File` being used anywhere in the generated code.

Thanks for creating `elm_rs`, it is a great tool!