### PR TITLE
Function application instead of combination

### DIFF
--- a/elm_rs/src/elm_encode.rs
+++ b/elm_rs/src/elm_encode.rs
@@ -383,7 +383,7 @@ impl_builtin_container!(
     Option<T>,
     "Maybe",
     "Json.Decode.nullable",
-    "Maybe.withDefault Json.Encode.null << Maybe.map"
+    "Maybe.withDefault Json.Encode.null <| Maybe.map"
 );
 impl_builtin!(
     std::path::Path,


### PR DESCRIPTION
Hi 👋,

I  love this crate! And I think I found a small typo. In my Rust code I have an `Optional` that I'm trying to serialize to Elm. 
However I get this error and I think this patch would fix it.
```
46|             Json.Encode.object [ ( "SaveNewDocumentSender", Json.Encode.object [ ( "id", documentIdEncoder id ), ( "new_sender", Maybe.withDefault Json.Encode.null << Maybe.map (actorIdEncoder) newSender ) ] ) ]
                                                                                                                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
This `map` call produces:

    Maybe Json.Encode.Value

But (<<) needs the right argument to be:

    a -> Maybe Json.Encode.Value
```