### PR TITLE
Fix error with missing () around Result parameters

### DIFF
--- a/elm_rs/src/elm.rs
+++ b/elm_rs/src/elm.rs
@@ -101,7 +101,7 @@ type alias Duration =
 
 impl<T: Elm, E: Elm> Elm for Result<T, E> {
     fn elm_type() -> String {
-        ::std::format!("Result {} {}", E::elm_type(), T::elm_type())
+        ::std::format!("Result ({}) ({})", E::elm_type(), T::elm_type())
     }
 
     fn elm_definition() -> Option<String> {

--- a/elm_rs/src/test/mod.rs
+++ b/elm_rs/src/test/mod.rs
@@ -13,6 +13,7 @@ mod enums_internal;
 mod enums_untagged;
 mod etc_serde;
 mod hygiene;
+mod nested;
 mod query;
 mod regression;
 mod structs;

--- a/elm_rs/src/test/nested.rs
+++ b/elm_rs/src/test/nested.rs
@@ -1,0 +1,18 @@
+use crate::{Elm, ElmDecode, ElmEncode};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Elm, ElmDecode, ElmEncode, Clone, Eq, PartialEq)]
+pub struct NestedTypes {
+    pub result: Result<Vec<String>, u32>,
+    pub option: Option<Vec<String>>,
+    pub vec: Vec<Vec<String>>,
+}
+
+#[test]
+fn nestedtypes() {
+    super::test_json(NestedTypes {
+        result: Ok(vec![]),
+        option: Some(vec![]),
+        vec: vec![vec![]],
+    });
+}


### PR DESCRIPTION
Hi!

Super useful crate!

I found that there where missing parenthesis in the generated Result type.

So
`Result<Vec<String>, u32>`

Would be generated as

`Result Int List (String)`

which is a compiler error, instead, it should be

`Result (Int) (List (String))`

I fixed that, and added a test as well. Seems excessive to create a new file just for this, but I wasn't sure where to put it.

